### PR TITLE
caddyfile: Fix nil map error, incorrect block level

### DIFF
--- a/caddyfile.go
+++ b/caddyfile.go
@@ -35,7 +35,7 @@ func parseApp(d *caddyfile.Dispenser, _ interface{}) (interface{}, error) {
 	for d.NextBlock(0) {
 		switch d.Val() {
 		case "domains":
-			for d.NextBlock(1) {
+			for nesting := d.Nesting(); d.NextBlock(nesting); {
 				zone := d.Val()
 				if zone == "" {
 					return nil, d.ArgErr()

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -35,7 +35,7 @@ func parseApp(d *caddyfile.Dispenser, _ interface{}) (interface{}, error) {
 	for d.NextBlock(0) {
 		switch d.Val() {
 		case "domains":
-			for d.NextBlock(0) {
+			for d.NextBlock(1) {
 				zone := d.Val()
 				if zone == "" {
 					return nil, d.ArgErr()

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -44,6 +44,9 @@ func parseApp(d *caddyfile.Dispenser, _ interface{}) (interface{}, error) {
 				if len(names) == 0 {
 					names = []string{"@"}
 				}
+				if app.Domains == nil {
+					app.Domains = make(map[string][]string)
+				}
 				app.Domains[zone] = names
 			}
 


### PR DESCRIPTION
```
panic: assignment to entry in nil map
goroutine 1 [running]:
github.com/mholt/caddy-dynamicdns.parseApp(0xc0006965d0, 0x0, 0x0, 0xb, 0x27d8ea0, 0x1, 0x0)
        github.com/mholt/caddy-dynamicdns@v0.0.0-20210227192534-aa9c81625585/caddyfile.go:47 +0x13b
github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile.ServerType.evaluateGlobalOptionsBlock(0xc000427ae0, 0x2, 0x2, 0xc0006962d0, 0xc00077efb0, 0x0, 0x0, 0x0, 0x0)
        github.com/caddyserver/caddy/v2@v2.4.0-beta.1.0.20210227022758-ec309c6d52fd/caddyconfig/httpcaddyfile/httptype.go:351 +0x228
github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile.ServerType.Setup(0xc0002a6660, 0x2, 0x2, 0xc0006962d0, 0xc0002a6600, 0x3, 0x4, 0x0, 0x0, 0x0)
        github.com/caddyserver/caddy/v2@v2.4.0-beta.1.0.20210227022758-ec309c6d52fd/caddyconfig/httpcaddyfile/httptype.go:86 +0x2af
github.com/caddyserver/caddy/v2/caddyconfig/caddyfile.Adapter.Adapt(0x1d5bc60, 0x27d6de0, 0xc0004d3400, 0x139, 0x200, 0xc0006962d0, 0xc000390b40, 0xbb00000000000000, 0xc00077f5d8, 0xbbeb0de81c2a79a2, ...)
        github.com/caddyserver/caddy/v2@v2.4.0-beta.1.0.20210227022758-ec309c6d52fd/caddyconfig/caddyfile/adapter.go:50 +0x167
github.com/caddyserver/caddy/v2/cmd.loadConfig(0x7fff30daceca, 0x14, 0x17c1389, 0x9, 0xc0001fc740, 0x203000, 0x0, 0x0, 0x0, 0x0, ...)
        github.com/caddyserver/caddy/v2@v2.4.0-beta.1.0.20210227022758-ec309c6d52fd/cmd/main.go:177 +0x582
github.com/caddyserver/caddy/v2/cmd.cmdRun(0xc00012b740, 0x0, 0x0, 0x0)
        github.com/caddyserver/caddy/v2@v2.4.0-beta.1.0.20210227022758-ec309c6d52fd/cmd/commandfuncs.go:203 +0x814
github.com/caddyserver/caddy/v2/cmd.Main()
        github.com/caddyserver/caddy/v2@v2.4.0-beta.1.0.20210227022758-ec309c6d52fd/cmd/main.go:85 +0x25b
main.main()
        caddy/main.go:13 +0x25
```