### PR TITLE
domains: merge zones with the same name

### DIFF
--- a/caddyfile.go
+++ b/caddyfile.go
@@ -66,7 +66,11 @@ func parseApp(d *caddyfile.Dispenser, _ interface{}) (interface{}, error) {
 				if app.Domains == nil {
 					app.Domains = make(map[string][]string)
 				}
-				app.Domains[zone] = names
+				if app.Domains[zone] != nil {
+					app.Domains[zone] = append(app.Domains[zone], names...)
+				} else {
+					app.Domains[zone] = names
+				}
 			}
 
 		case "update_only":

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -66,11 +66,7 @@ func parseApp(d *caddyfile.Dispenser, _ interface{}) (interface{}, error) {
 				if app.Domains == nil {
 					app.Domains = make(map[string][]string)
 				}
-				if app.Domains[zone] != nil {
-					app.Domains[zone] = append(app.Domains[zone], names...)
-				} else {
-					app.Domains[zone] = names
-				}
+				app.Domains[zone] = append(app.Domains[zone], names...)
 			}
 
 		case "update_only":

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -128,6 +128,30 @@ func Test_ParseApp(t *testing.T) {
 			}`),
 			wantErr: true,
 		},
+		{
+			name: "domains: zones get merged",
+			d: caddyfile.NewTestDispenser(`
+				dynamic_dns {
+					domains {
+						example @
+						example test
+						sub.example @
+					}
+				}
+			`),
+			want: ` {
+				"domains": {
+					"example": [
+						"@",
+						"test"
+					],
+					"sub.example": [
+						"@"
+					]
+				},
+				"versions": {}
+ 			}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR is the result of a feature request I made over at https://github.com/lucaslorentz/caddy-docker-proxy/issues/487.

Basically, I want to be able to repeat zones in the `domains` block, so I can have the domains I want to dynamically update spread out over my container labels when using _caddy-docker-proxy_ .

I made the simplest possible solution for this in this PR. I initially considered changing the `App.Domains` field to a list of some new struct, but decided not to do that to keep backwards compatibility in the JSON caddy config, and because the diff is smaller :slightly_smiling_face: 