### PR TITLE
Correctly detect current Cloudflare IPs

### DIFF
--- a/dynamicdns.go
+++ b/dynamicdns.go
@@ -204,7 +204,7 @@ func (a App) checkIPAndUpdateDNS() {
 	for _, ip := range currentIPs {
 		for zone, domains := range allDomains {
 			for _, domain := range domains {
-				oldIps, found := lastIPs[joinDomainZone(domain, zone)][recordType(ip)]
+				oldIps, found := lastIPs[libdns.AbsoluteName(domain, zone)][recordType(ip)]
 				if !found && a.UpdateOnly {
 					a.logger.Debug("record doesn't exist; skipping update",
 						zap.String("zone", zone),
@@ -252,7 +252,7 @@ func (a App) checkIPAndUpdateDNS() {
 			)
 		}
 		for _, rec := range records {
-			name := joinDomainZone(rec.Name, zone)
+			name := libdns.AbsoluteName(rec.Name, zone)
 			if lastIPs == nil {
 				lastIPs = make(domainTypeIPs)
 			}
@@ -294,7 +294,7 @@ func (a App) lookupCurrentIPsFromDNS(domains map[string][]string) (domainTypeIPs
 				a.logger.Debug("found DNS record", zap.String("type", r.Type), zap.String("name", r.Name), zap.String("zone", zone), zap.String("value", r.Value))
 				ip := net.ParseIP(r.Value)
 				if ip != nil {
-					name := joinDomainZone(r.Name, zone)
+					name := libdns.AbsoluteName(r.Name, zone)
 					if _, ok := recMap[name]; !ok {
 						recMap[name] = make(map[string]net.IP)
 					}
@@ -304,7 +304,7 @@ func (a App) lookupCurrentIPsFromDNS(domains map[string][]string) (domainTypeIPs
 				}
 			}
 			for _, n := range names {
-				name := joinDomainZone(n, zone)
+				name := libdns.AbsoluteName(n, zone)
 				ips := make(map[string][]net.IP)
 				for _, t := range types {
 					if ip, ok := recMap[name][t]; ok {
@@ -413,14 +413,6 @@ func ipListContains(list []net.IP, ip net.IP) bool {
 		}
 	}
 	return false
-}
-
-// joinDomainZone joins a domain and zone.
-func joinDomainZone(domain, zone string) string {
-	if domain == "" || domain == "@" {
-		return zone
-	}
-	return domain + "." + zone
 }
 
 // IPVersions is the IP versions to enable for dynamic DNS.

--- a/dynamicdns.go
+++ b/dynamicdns.go
@@ -417,7 +417,7 @@ func ipListContains(list []net.IP, ip net.IP) bool {
 
 // joinDomainZone joins a domain and zone.
 func joinDomainZone(domain, zone string) string {
-	if domain == "@" {
+	if domain == "" || domain == "@" {
 		return zone
 	}
 	return domain + "." + zone


### PR DESCRIPTION
When using the Cloudflare DNS provider, the current IPs are not detected correctly.

```
found DNS record	{"type": "A", "name": "", "zone": "example.com", "value": "12.34.56.78"}
found DNS record	{"type": "AAAA", "name": "", "zone": "example.com", "value": "2001:db8:3333:4444:5555:6666:7777:8888"}
domain not found in DNS	{"domain": "example.com"}
domain not found in DNS	{"domain": "example.com"}
looked up current IPs from DNS	{"lastIPs": {"example.com":{"A":[""],"AAAA":[""]}}}
```

The name in the Caddy config is `@`, but the name in the returned `Record` is the empty string. So we insert into `recMap` using `.example.com`, but lookup using `example.com`.

The `libdns` documentation isn't clear on the expected behavior of `Record.Name` for A records. If the empty string is a valid value for A records, then this PR is the correct fix. But if the value for A records should always be `@`, then this should be fixed in [libdns/cloudflare](https://github.com/libdns/cloudflare).

I assume this is the correct fix since it matches [similar code in libdns](https://github.com/libdns/libdns/blob/5344f2e6777eb6bf44f6f2dd24f13e1e326873c8/libdns.go#L212-L214).