### PR TITLE
Only use public global unicast addresses for NetInterface source

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ This updates DNS records for `example.com` via Cloudflare's API. (Notice how the
 
 Here's a more filled-out config, will all the options used.
 
-This config prefers to get the IP address locally via UPnP (if edge router has UPnP enabled, of course), but if that fails, will fall back to querying `icanhazip.com` for the IP address. It then updates records for `example.com`, `www.example.com`, and `subdomain.example.net`. Notice how the zones and subdomains are separate; this eliminates ambiguity since we don't have to try to be clever and figure out the zone via recursive, authoritative DNS lookups. We also check every 5 minutes instead of 30 minutes (default), and set a TTL of 1 hour for the records.
+This config prefers to get the IP address locally via UPnP (if edge router has UPnP enabled, of course), but if that fails, will fall back to querying `icanhazip.com` for the IP address. If those fail, it will try to find the IP address from the eth0 interface. It then updates records for `example.com`, `www.example.com`, and `subdomain.example.net`. Notice how the zones and subdomains are separate; this eliminates ambiguity since we don't have to try to be clever and figure out the zone via recursive, authoritative DNS lookups. We also check every 5 minutes instead of 30 minutes (default), and set a TTL of 1 hour for the records.
+
+The interface option will return at most 1 IPv4 and 1 IPv6 address. It will only return addresses that are not [private according to RFC 1918 (IPv4) and RFC 4193 (IPv6)](https://pkg.go.dev/net#IP.IsPrivate), and is a [global unicast address according to RFC 1122, RFC 4632, and RFC 4291 with the exception of IPv4 directed broadcast addresses](https://pkg.go.dev/net#IP.IsGlobalUnicast).
 
 Note that it's redundant to specify both IP versions in the config, since the default is to enable both IPv4 and IPv6. It's purpose is to allow disabling one or the other if your server is only reachable via one of the versions. It's included in this config example for posterity.
 

--- a/ipsource.go
+++ b/ipsource.go
@@ -240,7 +240,7 @@ func (u UPnP) GetIPs(ctx context.Context, _ IPVersions) ([]net.IP, error) {
 	return []net.IP{ip}, nil
 }
 
-// NetInterface gets the IP address from a network interface by name.
+// NetInterface gets the public IP address(es) (at most 1 IPv4 and 1 IPv6) from a network interface by name.
 type NetInterface struct {
 	// The name of the network interface.
 	Name string `json:"name,omitempty"`
@@ -271,7 +271,7 @@ func (u *NetInterface) Provision(ctx caddy.Context) error {
 	return nil
 }
 
-// GetIPs gets the public address(es) of from the network interface.
+// GetIPs gets the public address of from the network interface.
 func (u NetInterface) GetIPs(ctx context.Context, versions IPVersions) ([]net.IP, error) {
 	iface, err := net.InterfaceByName(u.Name)
 	if err != nil {

--- a/ipsource.go
+++ b/ipsource.go
@@ -299,6 +299,9 @@ func (u NetInterface) GetIPs(ctx context.Context, versions IPVersions) ([]net.IP
 			foundIPV6 = true
 			continue
 		}
+		if ( foundIPV4 || !versions.V4Enabled ) && ( foundIPV6 || !versions.V6Enabled ) {
+			break
+		}
 	}
 
 	stringIps := make([]string, len(ips))

--- a/ipsource.go
+++ b/ipsource.go
@@ -299,7 +299,7 @@ func (u NetInterface) GetIPs(ctx context.Context, versions IPVersions) ([]net.IP
 			foundIPV6 = true
 			continue
 		}
-		if ( foundIPV4 || !versions.V4Enabled ) && ( foundIPV6 || !versions.V6Enabled ) {
+		if ( foundIPV4 || !versions.V4Enabled() ) && ( foundIPV6 || !versions.V6Enabled() ) {
 			break
 		}
 	}

--- a/ipsource.go
+++ b/ipsource.go
@@ -285,7 +285,7 @@ func (u NetInterface) GetIPs(ctx context.Context, versions IPVersions) ([]net.IP
 	ips := []net.IP{}
 	for _, addr := range addrs {
 		ipNet, ok := addr.(*net.IPNet)
-		if !ok || ipNet.IP.IsLoopback() {
+		if !ok || ipNet.IP.IsLoopback() || ipNet.IP.IsPrivate() || !ipNet.IP.IsGlobalUnicast() {
 			continue
 		}
 		if versions.V4Enabled() && ipNet.IP.To4() != nil {

--- a/ipsource.go
+++ b/ipsource.go
@@ -283,17 +283,20 @@ func (u NetInterface) GetIPs(ctx context.Context, versions IPVersions) ([]net.IP
 	}
 
 	ips := []net.IP{}
+	foundIPV4, foundIPV6 := false, false
 	for _, addr := range addrs {
 		ipNet, ok := addr.(*net.IPNet)
 		if !ok || ipNet.IP.IsLoopback() || ipNet.IP.IsPrivate() || !ipNet.IP.IsGlobalUnicast() {
 			continue
 		}
-		if versions.V4Enabled() && ipNet.IP.To4() != nil {
+		if versions.V4Enabled() && !foundIPV4 && ipNet.IP.To4() != nil {
 			ips = append(ips, ipNet.IP)
+			foundIPV4 = true
 			continue
 		}
-		if versions.V6Enabled() && ipNet.IP.To16() != nil {
+		if versions.V6Enabled() && !foundIPV6 && ipNet.IP.To16() != nil {
 			ips = append(ips, ipNet.IP)
+			foundIPV6 = true
 			continue
 		}
 	}


### PR DESCRIPTION
#59 