### PR TITLE
Skip DNS check for wildcard hostnames

### DIFF
--- a/dynamicdns.go
+++ b/dynamicdns.go
@@ -304,6 +304,10 @@ func (a App) lookupCurrentIPsFromDNS(domains map[string][]string) (domainTypeIPs
 				}
 			}
 			for _, n := range names {
+				if n == "*" {
+					a.logger.Debug("skipping DNS record check for wildcard hostname", zap.String("name", n), zap.String("zone", zone))
+					continue
+				}
 				name := libdns.AbsoluteName(n, zone)
 				ips := make(map[string][]net.IP)
 				for _, t := range types {


### PR DESCRIPTION
Hey,

When using a wildcard hostname, DNS check fails with the following error:
```
{"msg":"domain not found in DNS","domain":"*.mytld.com"}
```

Wildcard hostname cannot be resolved, and this might be confusing to the user, since they might assume that something is not configured correctly (e.g. that DNS record is not present at the DNS server).

I suggest that we skip DNS checks in such case, because they cannot succeed.