### PR TITLE
Add type to domain-not-found error message

### DIFF
--- a/dynamicdns.go
+++ b/dynamicdns.go
@@ -310,7 +310,7 @@ func (a App) lookupCurrentIPsFromDNS(domains map[string][]string) (domainTypeIPs
 					if ip, ok := recMap[name][t]; ok {
 						ips[t] = []net.IP{ip}
 					} else {
-						a.logger.Info("domain not found in DNS", zap.String("domain", name))
+						a.logger.Info("domain not found in DNS", zap.String("domain", name), zap.String("type", t))
 						ips[t] = []net.IP{nilIP}
 					}
 				}


### PR DESCRIPTION
Related to #75.

Add record type to `domain not found in DNS` message, to avoid confusion, thinking that DNS record could not be fetched, when using only a single record type (either `A` or `AAAA`).

---

Output, when only `A` record is present:
```
2024/10/25 20:38:31.674 INFO    dynamic_dns     domain not found in DNS {"domain": "*.example.com", "type": "AAAA"}
```