### PR TITLE
Don't implicitly add "@" in Caddyfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Caddyfile config ([global options](https://caddyserver.com/docs/caddyfile/option
 	dynamic_dns {
 		provider cloudflare {env.CLOUDFLARE_API_TOKEN}
 		domains {
-			example.com
+			example.com @
 		}
 	}
 }
@@ -138,7 +138,7 @@ Caddyfile config:
 	dynamic_dns {
 		provider cloudflare {env.CLOUDFLARE_API_TOKEN}
 		domains {
-			example.com
+			example.com @
 		}
 		versions ipv6
 		ip_source interface eth0
@@ -187,7 +187,7 @@ Caddyfile config:
 	dynamic_dns {
 		provider cloudflare {env.CLOUDFLARE_API_TOKEN}
 		domains {
-			example.com
+			example.com @
 		}
 		versions ipv4
 	}

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -64,9 +64,6 @@ func parseApp(d *caddyfile.Dispenser, _ any) (any, error) {
 					return nil, d.ArgErr()
 				}
 				names := d.RemainingArgs()
-				if len(names) == 0 {
-					names = []string{"@"}
-				}
 				if app.Domains == nil {
 					app.Domains = make(map[string][]string)
 				}


### PR DESCRIPTION
Previously, if you only specified a zone name, e.g. "example.com", we would assume an implicit "@" and update the root zone name too. But as #93 shows, that is not always desireable.

This will break configurations who rely on this, so I will need to make this very clear in the release notes.

Fix #93