### PR TITLE
Properly unmap 4-in-6 addresses for ipv4 addresses when using `interface` to retrieve IPs

### DIFF
--- a/ipsource.go
+++ b/ipsource.go
@@ -403,8 +403,8 @@ func ipnetToPrefix(ipNet *net.IPNet) netip.Prefix {
 	if !ok {
 		return netip.Prefix{}
 	}
-	// Per doc, the standard `IPv4{}` structs uses 4-in-6 representation,
-	// which causes `addr.Is4()` fail for valid v4 addresses.
+	// Per the docs, the standard `IP{}` structs uses 4-in-6 representation when retrieve ips
+	// from the underlying iface, which causes `addr.Is4()` fail for valid v4 addresses.
 	// The `Unmap()` call will leave the `addr` unmodified if it's not a 4-in-6 addr.
 	addr = addr.Unmap()
 	prefixSize, _ := ipNet.Mask.Size()

--- a/ipsource.go
+++ b/ipsource.go
@@ -403,6 +403,10 @@ func ipnetToPrefix(ipNet *net.IPNet) netip.Prefix {
 	if !ok {
 		return netip.Prefix{}
 	}
+	// Per doc, the standard `IPv4{}` structs uses 4-in-6 representation,
+	// which causes `addr.Is4()` fail for valid v4 addresses.
+	// The `Unmap()` call will leave the `addr` unmodified if it's not a 4-in-6 addr.
+	addr = addr.Unmap()
 	prefixSize, _ := ipNet.Mask.Size()
 	return netip.PrefixFrom(addr, prefixSize)
 }


### PR DESCRIPTION
## Background

The current implementation takes the IPv4 addresses directly from the `iface.Addrs()`. However, the underlying `net.IP` value may represent IPv4 addresses using the 4-in-6 representation, which does not pass the `addr.Is4()` check here:

https://github.com/mholt/caddy-dynamicdns/blob/1af4f88765982db86ce091eeb075cfb2d9348dc8/ipsource.go#L318-L322

The document mentions the behaviour at: <https://pkg.go.dev/net/netip#Addr.Is4>.

## Fix

Just call the `Unmap()` after we get a valid `addr`. Per the docs, the call is safe for real IPv4 and IPv6 addresses.

I avoided adding an `addr.Is4in6()` check because I don't know whether the downstream usage rejects such addresses.

Closes #102.

> Disclaimer: The issue was found by an AI agent when I was debugging my own setup, but the commit is written by hand ;)